### PR TITLE
Added support for "errors" in GoToLua().

### DIFF
--- a/luar.go
+++ b/luar.go
@@ -373,6 +373,11 @@ func CopyMapToTable(L *lua.State, vmap reflect.Value) int {
 // If we haven't been given a concrete type, use the type of the value
 // and unbox any interfaces.
 func GoToLua(L *lua.State, t reflect.Type, val reflect.Value) {
+	if !val.IsValid() {
+		L.PushNil()
+		return
+	}
+
 	proxify := true
 	if t == nil {
 		t = val.Type()


### PR DESCRIPTION
Now you can do stuff like return an error from a function in Go or call a Lua callback with an error parameter.

e.g.

```
func hello() error {
  return errors.New("error occurred")
}

luar.Register(L, "", luar.Map{
  "hello": hello
})
```

and then in Lua:

```
err = hello()
if err ~= nil then
  print(err)
end
```

I also ran it through the default "go fmt".

The relevant piece of code is:

```
case reflect.Struct:
{
  if v, ok := val.Interface().(error); ok {
    L.PushString(v.Error())
  } else {
    makeValueProxy(L, val, STRUCT_META)
  }
}
default:
{
  if v, ok := val.Interface().(error); ok {
    L.PushString(v.Error())
  } else if val.IsNil() {
    L.PushNil()
  } else {
    makeValueProxy(L, val, INTERFACE_META)
  }
}
```
