### PR TITLE
PCall removal

### DIFF
--- a/luar.go
+++ b/luar.go
@@ -3,7 +3,6 @@ package luar
 import lua "github.com/aarzilli/golua/lua"
 import "fmt"
 import "strings"
-import "errors"
 
 //import "os"
 import "reflect"


### PR DESCRIPTION
I had to remove lua.State.PCall from golua. 
All lua code needs to be executed in a protected environment setup by golua or lua might longjump over pieces of go's own stack, which is bad. 
So there is no safe way to expose the lua_pcall interface to the user. I decided to remove it instead of exposing a fake one that ignores its third argument.
lua.State.Call uses lua_pcall in a safe way now.
Sorry for the trouble.
