### PR TITLE
fix typo in readme example #1

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ The first convenience is that ordinary Go functions may be registered directly:
 
         luar.Register(L,"",luar.Map{
             "Print":fmt.Println,
-            "MSG","hello",  // can also register constants
+            "MSG":"hello",  // can also register constants
         })
 
         L.DoString(test)


### PR DESCRIPTION
Even with this fix, I can't get the example to work (Go v1.1).  It errors out on the second pass through the loop: "runtime error: index out of range"

I have found that for any Lua script the first call to any function works, but others fail after that.

I'm just learning Go, so I don't know where to start to fix this.
