### PR TITLE
table should return nil if key does not exist

### DIFF
--- a/luar.go
+++ b/luar.go
@@ -249,10 +249,8 @@ func map__index(L *lua.State) int {
 	if ret.IsValid() {
 		GoToLua(L, ret.Type(), ret, false)
 		return 1
-	} else {
-		RaiseError(L, "cannot index this map with this type")
-		return 0
 	}
+	return 0
 }
 
 func map__newindex(L *lua.State) int {


### PR DESCRIPTION
Hi, thanks for updating 1.2!
I currently use map to table conversion in my project.
But I find if map__index raise error, I can't check key existence.

``` lua
if foo["bar"] == nil then -- just want to check key ("bar") existence, but raised

end
```
