### PR TITLE
Add support for converting Go struct to Lua tables

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2010
+Copyright (c) 2010-2016
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/doc.go
+++ b/doc.go
@@ -4,16 +4,12 @@
    Plain Go functions can be registered with luar and they will be called by reflection;
    methods on Go structs likewise.
 
-    package main
-
-   import "fmt"
-   import "github.com/stevedonovan/luar"
+   // import ...
 
    type MyStruct struct {
      Name string
      Age int
    }
-
 
    const test = `
    for i = 1,5 do

--- a/examples/struct.go
+++ b/examples/struct.go
@@ -1,14 +1,17 @@
 package main
 
-import "fmt"
-import "github.com/stevedonovan/luar"
+import (
+	"fmt"
+
+	"github.com/ambrevar/luar"
+)
 
 type Config struct {
-	Baggins bool
-	Age     int
-	Name    string
-	Ponies  []string
-	Father  *Config
+	Baggins bool     `lua:"baggins"`
+	Age     int      `lua:"age"`
+	Name    string   `lua:"name"`
+	Ponies  []string `lua:"ponies"`
+	Father  *Config  `lua:"father"`
 }
 
 func config(cfg *Config) {
@@ -17,8 +20,7 @@ func config(cfg *Config) {
 }
 
 // an example of using Lua for configuration...
-// Note that Lua names will be automatically
-// title-cased!
+// Note that Lua names will match the "lua" tags.
 const setup = `
 config {
   baggins = true,

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ directly go-gettable if the Lua package is installed.
 
 As a consequence, luar is also go-gettable.
 
-    go get github.com/stevedonovan/luar
+    go get <repo>/luar
 
 However, pkg-config is not universal, and Lua 5.1 may not
 be available as a lua5.1 package. However, cgo does not make any
@@ -41,8 +41,7 @@ The first convenience is that ordinary Go functions may be registered directly:
 ```go
 package main
 
-import "fmt"
-import "github.com/stevedonovan/luar"
+// import ...
 
 const test = `
 for i = 1,10 do
@@ -69,9 +68,7 @@ This example shows how Go slices and maps are marshalled to Lua tables and vice 
 ```go
 package main
 
-import "fmt"
-import "strconv"
-import "github.com/stevedonovan/luar"
+// import ...
 
 func GoFun (args []int) (res map[string]int) {
     res = make(map[string]int)


### PR DESCRIPTION
CopyStructToTable() is surprisingly (?) missing.
When converting from Lua to Go, Lua keys are not converted to title-case anymore. They must exactly match either the tag or the field name. This is more reliable and avoids unexpected behaviour.