### PR TITLE
Do not store Go pointers in C memory as valueProxy struct

### DIFF
--- a/proxymm.go
+++ b/proxymm.go
@@ -331,9 +331,9 @@ func proxy__eq(L *lua.State) int {
 }
 
 func proxy__gc(L *lua.State) int {
-	proxy := (*valueProxy)(L.ToUserdata(1))
+	proxyId := *(*uintptr)(L.ToUserdata(1))
 	proxymu.Lock()
-	delete(proxyMap, proxy)
+	delete(proxyMap, proxyId)
 	proxymu.Unlock()
 	return 0
 }


### PR DESCRIPTION
We already keep the proxy map around anyway, so not much should change.

The same thing is in the v2 branch, we simply can't write Go pointers into C-allocated memory - it shouldn't have worked before go1.8 either.

Fixes #38 