### PR TITLE
Support LUA_FUNCTION in luaToGo()

### DIFF
--- a/luar.go
+++ b/luar.go
@@ -806,6 +806,14 @@ func luaToGo(L *lua.State, idx int, v reflect.Value, visited map[uintptr]reflect
 		default:
 			return ConvError{From: luaDesc(L, idx), To: v.Type()}
 		}
+	case lua.LUA_TFUNCTION:
+		if kind == reflect.Interface {
+			v.Set(reflect.ValueOf(NewLuaObject(L, idx)))
+		} else if vp.Type() == reflect.TypeOf(&LuaObject{}) {
+			vp.Set(reflect.ValueOf(NewLuaObject(L, idx)))
+		} else {
+			return ConvError{From: luaDesc(L, idx), To: v.Type()}
+		}
 	default:
 		return ConvError{From: luaDesc(L, idx), To: v.Type()}
 	}


### PR DESCRIPTION
Support calls from lua to functions like this: 

```go
func Foo(callback *luar.LuaObject) {
    callback.Call(...)
}
func Bar(callbackObj interface{}) {
    callback, ok := callbackObj.(*luar.LuaObject)
    callback.Call(...)
}
```

This is a regression over v1 API, broke my scripts.

BTW, if I get `LuaObject` as argument like this, do I need to `.Close()` it at the end of the function?